### PR TITLE
Fix build script by renaming CMakeLists and adjusting target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,9 @@ project(load_balancer_project LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-# Conan injects Boost. CMake expects package name 'Boost'
-# and uses the imported target 'Boost::boost'.
+# Conan injects the Boost package, which CMake expects to be named
+# "Boost". The generated CMake targets use the lowercase
+# namespace, e.g. "boost::boost".
 find_package(Boost REQUIRED)
 
 # System threads
@@ -14,4 +15,4 @@ find_package(Threads REQUIRED)
 add_executable(rate_limiter src/rate_limiter.cpp)
 
 # Link Boost + Threads
-target_link_libraries(rate_limiter PRIVATE Boost::boost Threads::Threads)
+target_link_libraries(rate_limiter PRIVATE boost::boost Threads::Threads)


### PR DESCRIPTION
## Summary
- rename `CMakelists.txt` to standard `CMakeLists.txt`
- reference Boost package correctly
- clarify why Boost is capitalized

## Testing
- `bash build.sh --clean`
- `bash test.sh`


------
https://chatgpt.com/codex/tasks/task_e_6847d7f80edc8323a2a3008f56b09e5f