### PR TITLE
Add gtest-based coroutine unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,13 +9,28 @@ find_package(Boost REQUIRED)
 
 find_package(nlohmann_json REQUIRED)
 
+find_package(GTest REQUIRED)
+
 # System threads
 find_package(Threads REQUIRED)
 
 add_executable(rate_limiter src/rate_limiter.cpp)
 
-include_directories(rate_limiter PRIVATE ${CMAKE_SRC_DIR}/src)
+include_directories(rate_limiter PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
 # Link Boost + Threads
 target_link_libraries(rate_limiter PRIVATE Boost::boost Threads::Threads)
 target_link_libraries(rate_limiter PRIVATE nlohmann_json::nlohmann_json)
+
+enable_testing()
+
+add_executable(unit_tests
+  tests/token_bucket_test.cpp
+  tests/register_handler_test.cpp)
+target_include_directories(unit_tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(unit_tests PRIVATE
+  Boost::boost
+  Threads::Threads
+  GTest::gtest_main
+  nlohmann_json::nlohmann_json)
+add_test(NAME unit_tests COMMAND unit_tests)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,7 @@
 [requires]
 boost/1.84.0
 nlohmann_json/3.11.2
+gtest/1.14.0
 
 [options]
 boost/*:header_only=True  # We only use Beast/Asio headers!

--- a/src/token_bucket_rate_limiter.hpp
+++ b/src/token_bucket_rate_limiter.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <boost/asio.hpp>
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <memory>
+
+namespace net = boost::asio;
+
+class TokenBucketRateLimiter
+    : public std::enable_shared_from_this<TokenBucketRateLimiter> {
+public:
+  explicit TokenBucketRateLimiter(net::io_context& ctx) : ctx_(ctx) {}
+
+  void start_replenisher() {
+    net::co_spawn(
+        ctx_,
+        [weak_self = weak_from_this()]() -> net::awaitable<void> {
+          net::steady_timer timer(co_await net::this_coro::executor);
+
+          while (true) {
+            auto self = weak_self.lock();
+            if (!self) {
+              std::cout << "TokenBucketRateLimiter destroyed, exiting coroutine"
+                        << std::endl;
+              co_return;
+            }
+            std::cout << "Replenishing tokens" << std::endl;
+            self->tokens = MAX_TOKENS;
+            timer.expires_after(std::chrono::seconds(1));
+            co_await timer.async_wait(net::use_awaitable);
+          }
+        },
+        net::detached);
+  }
+
+  net::awaitable<bool> is_overloaded() {
+    auto current_tokens = tokens.load();
+    while (current_tokens > 0) {
+      if (tokens.compare_exchange_weak(current_tokens, current_tokens - 1)) {
+        co_return false;
+      }
+    }
+    co_return true;
+  }
+
+private:
+  static const int MAX_TOKENS = 200;
+  std::atomic<int> tokens{MAX_TOKENS};
+  net::io_context& ctx_;
+};

--- a/tests/register_handler_test.cpp
+++ b/tests/register_handler_test.cpp
@@ -1,0 +1,31 @@
+#include "register_handler.hpp"
+#include "registry.hpp"
+
+#include <gtest/gtest.h>
+
+TEST(RegisterHandler, RegistersBackend) {
+  BackendRegistry reg;
+  http::request<http::string_body> req{http::verb::post, "/register", 11};
+  req.set(http::field::content_type, "application/json");
+  req.body() = R"({"host":"127.0.0.1","port":9000})";
+  req.prepare_payload();
+
+  auto res = handle_register(req, reg);
+  EXPECT_EQ(res.result(), http::status::ok);
+
+  auto backend = reg.select_backend();
+  ASSERT_TRUE(backend.has_value());
+  EXPECT_EQ(backend->host, "127.0.0.1");
+  EXPECT_EQ(backend->port, 9000);
+}
+
+TEST(RegisterHandler, HandlesBadJson) {
+  BackendRegistry reg;
+  http::request<http::string_body> req{http::verb::post, "/register", 11};
+  req.set(http::field::content_type, "application/json");
+  req.body() = "{bad json}";
+  req.prepare_payload();
+
+  auto res = handle_register(req, reg);
+  EXPECT_EQ(res.result(), http::status::bad_request);
+}

--- a/tests/token_bucket_test.cpp
+++ b/tests/token_bucket_test.cpp
@@ -1,0 +1,30 @@
+#include "token_bucket_rate_limiter.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace std::chrono_literals;
+
+TEST(TokenBucketRateLimiter, NotOverloadedWhenTokensAvailable) {
+  net::io_context ctx;
+  auto limiter = std::make_shared<TokenBucketRateLimiter>(ctx);
+
+  auto fut = net::co_spawn(ctx, limiter->is_overloaded(), net::use_future);
+  ctx.run();
+  EXPECT_FALSE(fut.get());
+}
+
+TEST(TokenBucketRateLimiter, BecomesOverloadedAfterTokensExhausted) {
+  net::io_context ctx;
+  auto limiter = std::make_shared<TokenBucketRateLimiter>(ctx);
+
+  std::vector<std::future<bool>> results;
+  for (int i = 0; i < 201; ++i) {
+    results.push_back(net::co_spawn(ctx, limiter->is_overloaded(), net::use_future));
+  }
+  ctx.run();
+
+  for (int i = 0; i < 200; ++i) {
+    EXPECT_FALSE(results[i].get());
+  }
+  EXPECT_TRUE(results.back().get());
+}


### PR DESCRIPTION
## Summary
- add gtest to dependencies and integrate into CMake
- refactor token bucket limiter into header for reuse
- add unit tests for TokenBucketRateLimiter and register handler

## Testing
- `./build.sh`
- `./test.sh` *(fails: `bash: ./test.sh: cannot execute: required file not found`)*
- `./build/unit_tests --gtest_color=yes`


------
https://chatgpt.com/codex/tasks/task_e_684922af7f108323bca831ed5678aef1